### PR TITLE
Add support for tailwind-styled-components

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,14 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
+  "editor.quickSuggestions": {
+    "strings": true // forces VS Code to trigger completions when editing "string" content
+  },
+  "tailwindCSS.experimental.classRegex": [
+    "tw`([^`]*)", // tw`...`
+    "tw\\.[^`]+`([^`]*)`", // tw.xxx<xxx>`...`
+    "tw\\(.*?\\).*?`([^`]*)" // tw(Component)<xxx>`...`
+  ],
   "sqltools.connections": [
     {
       "previewLimit": 50,

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "prettier": "^2.8.8",
     "prisma": "^4.15.0",
     "prisma-erd-generator": "^1.7.0",
+    "tailwind-styled-components": "^2.2.0",
     "tailwindcss": "^3.3.2",
     "ts-node": "^10.9.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ devDependencies:
   prisma-erd-generator:
     specifier: ^1.7.0
     version: 1.7.0(@mermaid-js/mermaid-cli@10.1.0)(@prisma/client@4.15.0)(@prisma/generator-helper@4.15.0)
+  tailwind-styled-components:
+    specifier: ^2.2.0
+    version: 2.2.0(react-dom@18.2.0)(react@18.2.0)
   tailwindcss:
     specifier: ^3.3.2
     version: 3.3.2(ts-node@10.9.1)
@@ -7307,6 +7310,27 @@ packages:
     dependencies:
       "@pkgr/utils": 2.4.1
       tslib: 2.5.2
+
+  /tailwind-merge@1.13.0:
+    resolution:
+      {
+        integrity: sha512-mUTmDbcU+IhOvJ0c42eLQ/nRkvolTqfpVaVQRSxfJAv9TabS6Y2zW/1wKpKLdKzyL3Gh8j6NTLl6MWNmvOM6kA==,
+      }
+    dev: true
+
+  /tailwind-styled-components@2.2.0(react-dom@18.2.0)(react@18.2.0):
+    resolution:
+      {
+        integrity: sha512-Ogemwk0p69aU8WE/ooJZHjqstdJgT5R6HGU6TFz2uSnveSEtvW+C6aWOjGCvCr5H/bREv0IbbQ4yODknRrLBRQ==,
+      }
+    peerDependencies:
+      react: ">= 16.8.0"
+      react-dom: ">= 16.8.0"
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tailwind-merge: 1.13.0
+    dev: true
 
   /tailwindcss@3.3.2(ts-node@10.9.1):
     resolution:

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -5,7 +5,7 @@ import { PropsWithChildren } from "react";
 import AuthProvider from "@/contexts/AuthProvider";
 import { authOptions, makeRedirectURL, getOriginPath } from "@/shared/auth";
 import Navbar from "@/components/Navbar";
-import { container } from "@/shared/tw";
+import { Container } from "@/shared/components";
 
 export const metadata: Metadata = {
   title: "PodCodar Admin",
@@ -25,11 +25,11 @@ export default async function RootLayout({ children }: PropsWithChildren) {
         <header className="bg-white shadow">
           <Navbar />
 
-          <div className={container}>
+          <Container>
             <h1 className="text-3xl font-bold tracking-tight text-gray-900">
               Dashboard
             </h1>
-          </div>
+          </Container>
         </header>
 
         {children}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,4 +1,4 @@
-import { classes, container } from "@/shared/tw";
+import { Container } from "@/shared/components";
 
 type Status = "active" | "inactive";
 
@@ -44,7 +44,7 @@ const users: User[] = [
 
 export default function Dashboard() {
   return (
-    <div className={classes(container, "w-full grid p-8 gap-8")}>
+    <Container className="w-full grid p-8 gap-8">
       <div className="header flex w-full justify-between">
         <div className="flex-1">
           <h2 className="text-xl">Inscrito</h2>
@@ -89,6 +89,6 @@ export default function Dashboard() {
           </tbody>
         </table>
       </div>
-    </div>
+    </Container>
   );
 }

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -2,10 +2,10 @@ import { Metadata } from "next";
 import { PropsWithChildren } from "react";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
-import { container } from "@/shared/tw";
 import { authOptions, makeRedirectURL, getOriginPath } from "@/shared/auth";
 import Navbar from "@/components/Navbar";
 import AuthProvider from "@/contexts/AuthProvider";
+import { Container } from "@/shared/components";
 
 export const metadata: Metadata = {
   title: "PodCodar",
@@ -25,7 +25,7 @@ export default async function RootLayout({ children }: PropsWithChildren) {
         <Navbar />
       </header>
 
-      <div className={container}>{children}</div>
+      <Container>{children}</Container>
     </AuthProvider>
   );
 }

--- a/src/shared/components.tsx
+++ b/src/shared/components.tsx
@@ -1,3 +1,4 @@
+import tw from "tailwind-styled-components";
 import { classes } from "@/shared/tw";
 import {
   InputHTMLAttributes,
@@ -66,10 +67,10 @@ export const Input = forwardRef(function CustomInput(
   props: InputHTMLAttributes<HTMLInputElement>,
   ref: LegacyRef<HTMLInputElement>
 ) {
-  const styles = ` 
+  const styles = `
     block w-full rounded-md border-0 py-1.5 px-1.5 text-black
     shadow-sm ring-1 ring-inset ring-gray-300
-    placeholder:text-gray-400 sm:text-sm sm:leading-6 
+    placeholder:text-gray-400 sm:text-sm sm:leading-6
     ${focusStyles}
   `;
   return (
@@ -90,3 +91,10 @@ export const Image = (props: ImageProps) => {
     </div>
   );
 };
+
+export const Container = tw.div`
+  mx-auto
+  max-w-7xl
+  px-4 py-6
+  sm:px-6 lg:px-8
+`;

--- a/src/shared/tw.tsx
+++ b/src/shared/tw.tsx
@@ -1,7 +1,5 @@
-type Optional<T> = T | null | undefined;
+import { Optional } from "./types";
 
 export function classes(...classes: Optional<string>[]) {
   return classes.filter(Boolean).join(" ");
 }
-
-export const container = "mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,0 +1,1 @@
+export type Optional<T> = T | null | undefined;


### PR DESCRIPTION
# Description

This PR adds support for `tailwind-styled-components`

Other changes
- move optional to `types` utils 
- add vscode support
- create a container component & reuse it
