### PR TITLE
Refactoring shared components to user styled-components

### DIFF
--- a/src/shared/components.tsx
+++ b/src/shared/components.tsx
@@ -2,7 +2,6 @@ import tw from "tailwind-styled-components";
 import { classes } from "@/shared/tw";
 import {
   InputHTMLAttributes,
-  LabelHTMLAttributes,
   SelectHTMLAttributes,
   FormHTMLAttributes,
   HTMLAttributes,
@@ -58,10 +57,14 @@ export const Select = forwardRef(function CustomSelect(
   );
 });
 
-export const Label = (props: LabelHTMLAttributes<HTMLLabelElement>) => {
-  const styles = "block text-sm font-medium leading-6 text-white text-justify";
-  return <label {...props} className={classes(styles, props.className)} />;
-};
+export const Label = tw.label`
+  block
+  text-sm
+  font-medium
+  leading-6
+  text-white
+  text-justify
+`;
 
 export const Input = forwardRef(function CustomInput(
   props: InputHTMLAttributes<HTMLInputElement>,

--- a/src/shared/components.tsx
+++ b/src/shared/components.tsx
@@ -3,8 +3,6 @@ import { classes } from "@/shared/tw";
 import {
   InputHTMLAttributes,
   SelectHTMLAttributes,
-  FormHTMLAttributes,
-  HTMLAttributes,
   TextareaHTMLAttributes,
 } from "react";
 import NextImage, { ImageProps } from "next/image";
@@ -27,16 +25,23 @@ export const Textarea = forwardRef(function CustomTextarea(
   );
 });
 
-export const Title = (props: HTMLAttributes<HTMLHeadingElement>) => {
-  const styles =
-    "text-base text-lg text-center font-semibold leading-7 text-white";
-  return <h2 {...props} className={classes(styles, props.className)} />;
-};
+export const Title = tw.h1`
+  text-lg
+  text-center
+  font-semibold
+  leading-7
+  text-white
+`;
 
-export const Form = (props: FormHTMLAttributes<HTMLFormElement>) => {
-  const styles = "bg-pod-purple w-full mx-auto my-10 p-8 rounded-lg md:w-9/12";
-  return <form {...props} className={classes(styles, props.className)} />;
-};
+export const Form = tw.form`
+  bg-pod-purple
+  w-full
+  mx-auto
+  my-10
+  p-8
+  rounded-lg
+  md:w-9/12
+`;
 
 export const Select = forwardRef(function CustomSelect(
   props: SelectHTMLAttributes<HTMLSelectElement>,

--- a/src/shared/components.tsx
+++ b/src/shared/components.tsx
@@ -1,29 +1,5 @@
 import tw from "tailwind-styled-components";
-import { classes } from "@/shared/tw";
-import {
-  InputHTMLAttributes,
-  SelectHTMLAttributes,
-  TextareaHTMLAttributes,
-} from "react";
 import NextImage, { ImageProps } from "next/image";
-
-import { forwardRef, LegacyRef } from "react";
-
-const focusStyles = "focus:ring-2 focus:ring-inset focus:ring-indigo-600";
-
-export const Textarea = forwardRef(function CustomTextarea(
-  props: TextareaHTMLAttributes<HTMLTextAreaElement>,
-  ref: LegacyRef<HTMLTextAreaElement>
-) {
-  const styles = "w-full rounded-lg border-gray-200 p-3 text-sm";
-  return (
-    <textarea
-      {...props}
-      className={classes(styles, props.className)}
-      ref={ref}
-    />
-  );
-});
 
 export const Title = tw.h1`
   text-lg
@@ -43,25 +19,6 @@ export const Form = tw.form`
   md:w-9/12
 `;
 
-export const Select = forwardRef(function CustomSelect(
-  props: SelectHTMLAttributes<HTMLSelectElement>,
-  ref: LegacyRef<HTMLSelectElement>
-) {
-  const styles = `
-    block w-full rounded-md border-0 py-1.5 px-1.5 text-black
-    shadow-sm ring-1 ring-inset ring-gray-300
-    sm:max-w-xs sm:text-sm sm:leading-6
-    ${focusStyles}
-  `;
-  return (
-    <select
-      {...props}
-      className={classes(styles, props.className)}
-      ref={ref}
-    />
-  );
-});
-
 export const Label = tw.label`
   block
   text-sm
@@ -71,24 +28,34 @@ export const Label = tw.label`
   text-justify
 `;
 
-export const Input = forwardRef(function CustomInput(
-  props: InputHTMLAttributes<HTMLInputElement>,
-  ref: LegacyRef<HTMLInputElement>
-) {
-  const styles = `
-    block w-full rounded-md border-0 py-1.5 px-1.5 text-black
-    shadow-sm ring-1 ring-inset ring-gray-300
-    placeholder:text-gray-400 sm:text-sm sm:leading-6
-    ${focusStyles}
-  `;
-  return (
-    <input
-      {...props}
-      className={classes(styles, props.className)}
-      ref={ref}
-    />
-  );
-});
+const focusStyles = () => `
+  focus:ring-2
+  focus:ring-inset
+  focus:ring-indigo-600
+`;
+
+export const Select = tw.select`
+  block w-full rounded-md border-0 py-1.5 px-1.5 text-black
+  shadow-sm ring-1 ring-inset ring-gray-300
+  sm:max-w-xs sm:text-sm sm:leading-6
+  ${focusStyles}
+`;
+
+export const Input = tw.input`
+  block w-full rounded-md border-0 py-1.5 px-1.5 text-black
+  shadow-sm ring-1 ring-inset ring-gray-300
+  placeholder:text-gray-400 sm:text-sm sm:leading-6
+  ${focusStyles}
+`;
+
+export const Textarea = tw.textarea`
+  p-3
+  w-full
+  rounded-lg
+  border-gray-200
+  text-sm
+  ${focusStyles}
+`;
 
 export const Image = (props: ImageProps) => (
   <ImageWrapper height={props.height} width={props.width}>

--- a/src/shared/components.tsx
+++ b/src/shared/components.tsx
@@ -82,15 +82,26 @@ export const Input = forwardRef(function CustomInput(
   );
 });
 
-export const Image = (props: ImageProps) => {
-  const wrapperStyle = `max-w-[${props.width}px] max-h-[${props.height}px] flex flex-1`;
-  const imageStyle = "h-full w-full object-cover";
-  return (
-    <div className={wrapperStyle}>
-      <NextImage {...props} className={classes(imageStyle, props.className)} />
-    </div>
-  );
-};
+export const Image = (props: ImageProps) => (
+  <ImageWrapper height={props.height} width={props.width}>
+    <ImageStyled {...props} />
+  </ImageWrapper>
+);
+
+type WrapperProps = Pick<ImageProps, "width" | "height">;
+
+const ImageWrapper = tw.div<WrapperProps>`
+  flex
+  flex-1
+  max-w-[${(p) => p.width}px]
+  max-h-[${(p) => p.height}px]
+`;
+
+const ImageStyled = tw(NextImage)`
+  h-full
+  w-full
+  object-cover
+`;
 
 export const Container = tw.div`
   mx-auto


### PR DESCRIPTION
# Description

This PR applies `tailwind-styled-components` to all shared components

- update Image components
- update form and input components
- remove `forwardRef`
