### PR TITLE
Use data from DB instead of NextAuth Session on Navbar 

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,11 +1,11 @@
 import { Metadata } from "next";
 import { getServerSession } from "next-auth";
-import { redirect } from "next/navigation";
 import { PropsWithChildren } from "react";
 import AuthProvider from "@/contexts/AuthProvider";
-import { authOptions, makeRedirectURL, getOriginPath } from "@/shared/auth";
+import { authOptions } from "@/shared/auth";
 import Navbar from "@/components/Navbar";
 import { Container } from "@/shared/components";
+import { fetchUserWithSession } from "@/shared/db";
 
 export const metadata: Metadata = {
   title: "PodCodar Admin",
@@ -14,16 +14,13 @@ export const metadata: Metadata = {
 export default async function RootLayout({ children }: PropsWithChildren) {
   const session = await getServerSession(authOptions);
 
-  if (!session) {
-    const origin = getOriginPath();
-    return redirect(makeRedirectURL(origin));
-  }
+  const loggedUser = await fetchUserWithSession(session);
 
   return (
     <body>
       <AuthProvider>
         <header className="bg-white shadow">
-          <Navbar />
+          <Navbar loggedUser={loggedUser} />
 
           <Container>
             <h1 className="text-3xl font-bold tracking-tight text-gray-900">

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -1,11 +1,11 @@
 import { Metadata } from "next";
 import { PropsWithChildren } from "react";
 import { getServerSession } from "next-auth";
-import { redirect } from "next/navigation";
-import { authOptions, makeRedirectURL, getOriginPath } from "@/shared/auth";
+import { authOptions } from "@/shared/auth";
 import Navbar from "@/components/Navbar";
 import AuthProvider from "@/contexts/AuthProvider";
 import { Container } from "@/shared/components";
+import { fetchUserWithSession } from "@/shared/db";
 
 export const metadata: Metadata = {
   title: "PodCodar",
@@ -14,15 +14,12 @@ export const metadata: Metadata = {
 export default async function RootLayout({ children }: PropsWithChildren) {
   const session = await getServerSession(authOptions);
 
-  if (!session) {
-    const origin = getOriginPath();
-    return redirect(makeRedirectURL(origin));
-  }
+  const loggedUser = await fetchUserWithSession(session);
 
   return (
     <AuthProvider>
       <header className="bg-white shadow">
-        <Navbar />
+        <Navbar loggedUser={loggedUser} />
       </header>
 
       <Container>{children}</Container>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,5 @@
-// This code is based on the example from https://tailwindui.com/components/application-ui/navigation/navbars
 "use client";
+// This code is based on the example from https://tailwindui.com/components/application-ui/navigation/navbars
 import { Fragment } from "react";
 import { signOut } from "next-auth/react";
 import { Disclosure, Menu, Transition } from "@headlessui/react";
@@ -7,17 +7,17 @@ import { Bars3Icon, BellIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { Logo } from "./Logo";
 import { classes } from "@/shared/tw";
 import Image from "next/image";
-import { useSession } from "next-auth/react";
+import { User } from "@prisma/client";
 
 const navigation = [{ name: "Home", href: "/app", current: true }];
 
 const profileLinks = [{ name: "Sign out", onClick: () => signOut() }];
 
-export default function Navbar() {
-  const { data: session } = useSession();
+type Props = {
+  loggedUser: User;
+};
 
-  const user = session?.user;
-
+export default function Navbar({ loggedUser }: Props) {
   return (
     <Disclosure as="nav" className="bg-gray-800">
       {({ open }) => (
@@ -67,7 +67,7 @@ export default function Navbar() {
                           alt=""
                           className="h-8 w-8 rounded-full"
                           height="32"
-                          src={user?.image as string}
+                          src={loggedUser.avatar}
                           width="32"
                         />
                       </Menu.Button>
@@ -143,16 +143,16 @@ export default function Navbar() {
                     alt=""
                     className="h-10 w-10 rounded-full"
                     height="40"
-                    src={user?.image as string}
+                    src={loggedUser.avatar}
                     width="40"
                   />
                 </div>
                 <div className="ml-3">
                   <div className="text-base font-medium leading-none text-white">
-                    {user?.name}
+                    {loggedUser.name}
                   </div>
                   <div className="text-sm font-medium leading-none text-gray-400">
-                    {user?.email}
+                    {loggedUser.email}
                   </div>
                 </div>
                 <button

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -8,6 +8,7 @@ import { Logo } from "./Logo";
 import { classes } from "@/shared/tw";
 import Image from "next/image";
 import { User } from "@prisma/client";
+import Link from "next/link";
 
 const navigation = [{ name: "Home", href: "/app", current: true }];
 
@@ -82,6 +83,21 @@ export default function Navbar({ loggedUser }: Props) {
                       leaveTo="transform opacity-0 scale-95"
                     >
                       <Menu.Items className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+                        <Menu.Item>
+                          {({ active }) => (
+                            <Link href={`/app/${loggedUser.username}`}>
+                              <Disclosure.Button
+                                as="button"
+                                className={classes(
+                                  active ? "bg-gray-100" : "",
+                                  "block px-4 py-2 text-sm text-gray-700 w-full"
+                                )}
+                              >
+                                Meu Perfil
+                              </Disclosure.Button>
+                            </Link>
+                          )}
+                        </Menu.Item>
                         {profileLinks.map((item) => (
                           <Menu.Item key={item.name}>
                             {({ active }) => (
@@ -139,13 +155,15 @@ export default function Navbar({ loggedUser }: Props) {
             <div className="border-t border-gray-700 pb-3 pt-4">
               <div className="flex items-center px-5">
                 <div className="flex-shrink-0">
-                  <Image
-                    alt=""
-                    className="h-10 w-10 rounded-full"
-                    height="40"
-                    src={loggedUser.avatar}
-                    width="40"
-                  />
+                  <Link href={`/app/${loggedUser.username}`}>
+                    <Image
+                      alt=""
+                      className="h-10 w-10 rounded-full"
+                      height="40"
+                      src={loggedUser.avatar}
+                      width="40"
+                    />
+                  </Link>
                 </div>
                 <div className="ml-3">
                   <div className="text-base font-medium leading-none text-white">

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -1,5 +1,7 @@
 import { PrismaClient, Prisma } from "@prisma/client";
-import { User as NextUser } from "next-auth";
+import { User as NextUser, Session } from "next-auth";
+import { getOriginPath, makeRedirectURL } from "./auth";
+import { redirect } from "next/navigation";
 
 export const prisma = new PrismaClient();
 
@@ -32,4 +34,20 @@ function parseNextAuthUser(loginUser: NextUser): Prisma.UserCreateInput {
     name: loginUser.name ?? "",
     avatar: loginUser.image ?? undefined,
   };
+}
+
+export async function fetchUserWithSession(session: Session | null) {
+  if (!session?.user?.email) {
+    const origin = getOriginPath();
+    return redirect(makeRedirectURL(origin));
+  }
+
+  const loggedUser = await fetchUserBy({ email: session.user.email });
+
+  if (!loggedUser) {
+    const origin = getOriginPath();
+    return redirect(makeRedirectURL(origin));
+  }
+
+  return loggedUser;
 }

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -37,17 +37,13 @@ function parseNextAuthUser(loginUser: NextUser): Prisma.UserCreateInput {
 }
 
 export async function fetchUserWithSession(session: Session | null) {
-  if (!session?.user?.email) {
-    const origin = getOriginPath();
-    return redirect(makeRedirectURL(origin));
-  }
+  const redirectUrl = makeRedirectURL(getOriginPath());
+
+  if (!session?.user?.email) return redirect(redirectUrl);
 
   const loggedUser = await fetchUserBy({ email: session.user.email });
 
-  if (!loggedUser) {
-    const origin = getOriginPath();
-    return redirect(makeRedirectURL(origin));
-  }
+  if (!loggedUser) return redirect(redirectUrl);
 
   return loggedUser;
 }


### PR DESCRIPTION
# Description

This PR makes Navbar use data from DB instead of NextAuth Session

- Navbar now uses User data from the DB that comes through props
- Create a function to fetch `User` from the DB using `session` data
- Use the `fetchUserWithSession` to pass the `loggedUser` info from DB to Navbar as props
- Add Links to profile page on the Navbar

## Next Steps

- Allow user to edit profile info
