### PR TITLE
Create DB seed function

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,18 @@ services:
     depends_on:
       - db
 
+  seed:
+    build:
+      context: .
+      target: development
+    env_file: .env.postgres
+    command: pnpm db:seed
+    volumes:
+      - .:/app
+      - /app/node_modules
+    depends_on:
+      - db
+
   integration-test:
     build:
       context: .

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "app",
   "version": "0.1.0",
   "private": true,
+  "prisma": {
+    "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -14,8 +17,10 @@
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate",
     "db:studio": "prisma studio",
+    "db:seed": "prisma db seed",
     "dk:start": "concurrently 'pnpm dev' 'pnpm db:studio --browser none'",
     "migrate": "docker-compose run -it migrate",
+    "seed": "docker-compose run -it seed",
     "app:up": "docker-compose up app",
     "e2e:run": "docker-compose run integration-test",
     "down": "docker-compose down",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { prisma } from "@/shared/db";
 
 async function main() {
   const tasksData = [

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,54 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const tasksData = [
+    {
+      title: "Seed Task 1",
+      description: "Description for Seed Task 1",
+    },
+    {
+      title: "Seed Task 2",
+      description: "Description for Seed Task 2",
+    },
+    {
+      title: "Seed Task 3",
+      description: "Description for Seed Task 3",
+    },
+  ];
+
+  await prisma.task.createMany({
+    data: tasksData,
+  });
+
+  const tasks = await prisma.task.findMany();
+
+  const task1 = tasks[0];
+  const task2 = tasks[1];
+  const task3 = tasks[2];
+
+  await prisma.tasksDependencies.create({
+    data: {
+      task: { connect: { id: task2.id } },
+      dependentTask: { connect: { id: task1.id } },
+    },
+  });
+
+  await prisma.tasksDependencies.create({
+    data: {
+      task: { connect: { id: task3.id } },
+      dependentTask: { connect: { id: task1.id } },
+    },
+  });
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/src/app/app/onboarding/layout.tsx
+++ b/src/app/app/onboarding/layout.tsx
@@ -14,9 +14,7 @@ const steps: Step[] = [
   { content: OnboardingAbout },
 ];
 
-export default async function OnboardingLayout({
-  children,
-}: PropsWithChildren) {
+export default function OnboardingLayout({ children }: PropsWithChildren) {
   const searchParams = useSearchParams();
   const initialStep = searchParams.get("step") ?? "0";
 

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -1,12 +1,13 @@
 import { PrismaClient, Prisma } from "@prisma/client";
 import { User as NextUser } from "next-auth";
+import { raise } from "./exceptions";
 
 export const prisma = new PrismaClient();
 
 class UserDAO {
   async createUser(loginUser: NextUser) {
     const existingUser = await this.fetchUserBy({
-      email: loginUser.email!,
+      email: loginUser.email ?? raise("E-mail not found"),
     });
 
     if (existingUser) return existingUser;

--- a/src/tests/db.test.ts
+++ b/src/tests/db.test.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/shared/db";
 import { seed, teardown } from "./db.utils";
+import { raise } from "@/shared/exceptions";
 
 beforeAll(seed);
 
@@ -11,6 +12,7 @@ describe("user test cases", () => {
     const user = await prisma.user.findFirst({
       where: { username },
     });
+
     expect(user).not.toBeNull();
     expect(user?.username).toBe(username);
   });
@@ -20,10 +22,10 @@ describe("user test cases", () => {
       where: { id: 2 },
     });
 
-    expect(user).not.toBeNull();
+    if (!user) return raise("User not created");
 
     const userTasks = await prisma.userTasks.findMany({
-      where: { userId: user!.id },
+      where: { userId: user.id },
     });
 
     expect(userTasks).toHaveLength(2);
@@ -34,10 +36,10 @@ describe("user test cases", () => {
     const anotherTask = await prisma.task.findFirst({ where: { id: 2 } });
 
     for (const t of [task, anotherTask]) {
-      expect(t).not.toBeNull();
+      if (!t) return raise("Task not created");
 
       const userTasks = await prisma.userTasks.findMany({
-        where: { taskId: t!.id },
+        where: { taskId: t.id },
       });
 
       expect(userTasks.length).toBeGreaterThan(0);
@@ -47,20 +49,20 @@ describe("user test cases", () => {
   it("should be able to fetch dependent tasks from a giving task", async () => {
     const task = await prisma.task.findFirst({ where: { id: 2 } });
 
-    expect(task).not.toBeNull();
+    if (!task) return raise("Task not created");
 
     let dependentTasks = await prisma.tasksDependencies.findMany({
-      where: { task: task! },
+      where: { task: task },
     });
 
     expect(dependentTasks).toHaveLength(0);
 
     const anotherTask = await prisma.task.findFirst({ where: { id: 1 } });
 
-    expect(anotherTask).not.toBeNull();
+    if (!anotherTask) return raise("Task not created");
 
     dependentTasks = await prisma.tasksDependencies.findMany({
-      where: { task: anotherTask! },
+      where: { task: anotherTask },
     });
 
     expect(dependentTasks).toHaveLength(1);

--- a/src/tests/db.utils.ts
+++ b/src/tests/db.utils.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/shared/db";
+import { raise } from "@/shared/exceptions";
 
 export const seed = async () => {
   // create product categories
@@ -19,6 +20,8 @@ export const seed = async () => {
     prisma.user.findUnique({ where: { username: "josh" } }),
     prisma.user.findUnique({ where: { username: "danny" } }),
   ]);
+
+  if (!amy || !josh || !danny) return raise("Users not created");
 
   console.log("✨ 3 users successfully created!");
 
@@ -45,15 +48,17 @@ export const seed = async () => {
     whereList.map((where) => prisma.task.findUnique({ where }))
   );
 
+  if (!t1 || !t2) return raise("Tasks not created");
+
   console.log("✨ 3 tasks successfully created!");
 
   // create user tasks
   await prisma.userTasks.createMany({
     data: [
-      { completed: false, taskId: t1!.id, userId: amy!.id },
-      { completed: true, taskId: t1!.id, userId: josh!.id },
-      { completed: true, taskId: t1!.id, userId: danny!.id },
-      { completed: false, taskId: t2!.id, userId: josh!.id },
+      { completed: false, taskId: t1.id, userId: amy.id },
+      { completed: true, taskId: t1.id, userId: josh.id },
+      { completed: true, taskId: t1.id, userId: danny.id },
+      { completed: false, taskId: t2.id, userId: josh.id },
     ],
   });
 
@@ -62,8 +67,8 @@ export const seed = async () => {
   // create tasks dependencies
   await prisma.tasksDependencies.create({
     data: {
-      taskId: t1!.id,
-      dependentTaskId: t2!.id,
+      taskId: t1.id,
+      dependentTaskId: t2.id,
     },
   });
 


### PR DESCRIPTION
# Description

This PR creates a DB seed function

- Update project dependencies
- Add prisma key and seed script
- Create seed function on `seed.ts`

obs. Seed function cannot use createMany on many-to-many relationships, like tasks dependencies. But it could be used to create users indeed and this was changed - [see docs.](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#create-a-single-record-and-multiple-related-records)
