### PR TITLE
Fix Docker-compose Seeding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       context: .
       target: development
     env_file: .env.postgres
-    command: pnpm db:seed
+    command: pnpm i && pnpm db:seed
     volumes:
       - .:/app
       - /app/node_modules

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "prisma": {
-    "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
+    "seed": "ts-node --project tsconfig.json --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
   },
   "scripts": {
     "dev": "next dev",
@@ -68,6 +68,7 @@
     "prisma-erd-generator": "^1.7.0",
     "tailwind-styled-components": "^2.2.0",
     "tailwindcss": "^3.3.2",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "tsconfig-paths": "^4.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: "6.0"
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   "@headlessui/react":
     specifier: ^1.7.14
@@ -117,6 +121,9 @@ devDependencies:
   ts-node:
     specifier: ^10.9.1
     version: 10.9.1(@types/node@18.16.3)(typescript@5.0.2)
+  tsconfig-paths:
+    specifier: ^4.2.0
+    version: 4.2.0
 
 packages:
   /@adobe/css-tools@4.2.0:
@@ -1066,10 +1073,10 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@next/env@13.4.10:
+  /@next/env@13.4.12:
     resolution:
       {
-        integrity: sha512-3G1yD/XKTSLdihyDSa8JEsaWOELY+OWe08o0LUYzfuHp1zHDA8SObQlzKt+v+wrkkPcnPweoLH1ImZeUa0A1NQ==,
+        integrity: sha512-RmHanbV21saP/6OEPBJ7yJMuys68cIf8OBBWd7+uj40LdpmswVAwe1uzeuFyUsd6SfeITWT3XnQfn6wULeKwDQ==,
       }
     dev: true
 
@@ -1089,19 +1096,19 @@ packages:
       glob: 7.1.7
     dev: false
 
-  /@next/eslint-plugin-next@13.4.10:
+  /@next/eslint-plugin-next@13.4.12:
     resolution:
       {
-        integrity: sha512-YJqyq6vk39JQfvaNtN83t/p5Jy45+bazRL+V4QI8FPd3FBqFYMEsULiwRLgSJMgFqkk4t4JbeZurz+gILEAFpA==,
+        integrity: sha512-6rhK9CdxEgj/j1qvXIyLTWEaeFv7zOK8yJMulz3Owel0uek0U9MJCGzmKgYxM3aAUBo3gKeywCZKyQnJKto60A==,
       }
     dependencies:
       glob: 7.1.7
     dev: true
 
-  /@next/swc-darwin-arm64@13.4.10:
+  /@next/swc-darwin-arm64@13.4.12:
     resolution:
       {
-        integrity: sha512-4bsdfKmmg7mgFGph0UorD1xWfZ5jZEw4kKRHYEeTK9bT1QnMbPVPlVXQRIiFPrhoDQnZUoa6duuPUJIEGLV1Jg==,
+        integrity: sha512-deUrbCXTMZ6ZhbOoloqecnUeNpUOupi8SE2tx4jPfNS9uyUR9zK4iXBvH65opVcA/9F5I/p8vDXSYbUlbmBjZg==,
       }
     engines: { node: ">= 10" }
     cpu: [arm64]
@@ -1122,10 +1129,10 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-darwin-x64@13.4.10:
+  /@next/swc-darwin-x64@13.4.12:
     resolution:
       {
-        integrity: sha512-ngXhUBbcZIWZWqNbQSNxQrB9T1V+wgfCzAor2olYuo/YpaL6mUYNUEgeBMhr8qwV0ARSgKaOp35lRvB7EmCRBg==,
+        integrity: sha512-WRvH7RxgRHlC1yb5oG0ZLx8F7uci9AivM5/HGGv9ZyG2Als8Ij64GC3d+mQ5sJhWjusyU6T6V1WKTUoTmOB0zQ==,
       }
     engines: { node: ">= 10" }
     cpu: [x64]
@@ -1146,10 +1153,10 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-gnu@13.4.10:
+  /@next/swc-linux-arm64-gnu@13.4.12:
     resolution:
       {
-        integrity: sha512-SjCZZCOmHD4uyM75MVArSAmF5Y+IJSGroPRj2v9/jnBT36SYFTORN8Ag/lhw81W9EeexKY/CUg2e9mdebZOwsg==,
+        integrity: sha512-YEKracAWuxp54tKiAvvq73PUs9lok57cc8meYRibTWe/VdPB2vLgkTVWFcw31YDuRXdEhdX0fWS6Q+ESBhnEig==,
       }
     engines: { node: ">= 10" }
     cpu: [arm64]
@@ -1170,10 +1177,10 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-musl@13.4.10:
+  /@next/swc-linux-arm64-musl@13.4.12:
     resolution:
       {
-        integrity: sha512-F+VlcWijX5qteoYIOxNiBbNE8ruaWuRlcYyIRK10CugqI/BIeCDzEDyrHIHY8AWwbkTwe6GRHabMdE688Rqq4Q==,
+        integrity: sha512-LhJR7/RAjdHJ2Isl2pgc/JaoxNk0KtBgkVpiDJPVExVWA1c6gzY57+3zWuxuyWzTG+fhLZo2Y80pLXgIJv7g3g==,
       }
     engines: { node: ">= 10" }
     cpu: [arm64]
@@ -1194,10 +1201,10 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-gnu@13.4.10:
+  /@next/swc-linux-x64-gnu@13.4.12:
     resolution:
       {
-        integrity: sha512-WDv1YtAV07nhfy3i1visr5p/tjiH6CeXp4wX78lzP1jI07t4PnHHG1WEDFOduXh3WT4hG6yN82EQBQHDi7hBrQ==,
+        integrity: sha512-1DWLL/B9nBNiQRng+1aqs3OaZcxC16Nf+mOnpcrZZSdyKHek3WQh6j/fkbukObgNGwmCoVevLUa/p3UFTTqgqg==,
       }
     engines: { node: ">= 10" }
     cpu: [x64]
@@ -1218,10 +1225,10 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-musl@13.4.10:
+  /@next/swc-linux-x64-musl@13.4.12:
     resolution:
       {
-        integrity: sha512-zFkzqc737xr6qoBgDa3AwC7jPQzGLjDlkNmt/ljvQJ/Veri5ECdHjZCUuiTUfVjshNIIpki6FuP0RaQYK9iCRg==,
+        integrity: sha512-kEAJmgYFhp0VL+eRWmUkVxLVunn7oL9Mdue/FS8yzRBVj7Z0AnIrHpTIeIUl1bbdQq1VaoOztnKicAjfkLTRCQ==,
       }
     engines: { node: ">= 10" }
     cpu: [x64]
@@ -1242,10 +1249,10 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-arm64-msvc@13.4.10:
+  /@next/swc-win32-arm64-msvc@13.4.12:
     resolution:
       {
-        integrity: sha512-IboRS8IWz5mWfnjAdCekkl8s0B7ijpWeDwK2O8CdgZkoCDY0ZQHBSGiJ2KViAG6+BJVfLvcP+a2fh6cdyBr9QQ==,
+        integrity: sha512-GMLuL/loR6yIIRTnPRY6UGbLL9MBdw2anxkOnANxvLvsml4F0HNIgvnU3Ej4BjbqMTNjD4hcPFdlEow4XHPdZA==,
       }
     engines: { node: ">= 10" }
     cpu: [arm64]
@@ -1266,10 +1273,10 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-ia32-msvc@13.4.10:
+  /@next/swc-win32-ia32-msvc@13.4.12:
     resolution:
       {
-        integrity: sha512-bSA+4j8jY4EEiwD/M2bol4uVEu1lBlgsGdvM+mmBm/BbqofNBfaZ2qwSbwE2OwbAmzNdVJRFRXQZ0dkjopTRaQ==,
+        integrity: sha512-PhgNqN2Vnkm7XaMdRmmX0ZSwZXQAtamBVSa9A/V1dfKQCV1rjIZeiy/dbBnVYGdj63ANfsOR/30XpxP71W0eww==,
       }
     engines: { node: ">= 10" }
     cpu: [ia32]
@@ -1290,10 +1297,10 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-x64-msvc@13.4.10:
+  /@next/swc-win32-x64-msvc@13.4.12:
     resolution:
       {
-        integrity: sha512-g2+tU63yTWmcVQKDGY0MV1PjjqgZtwM4rB1oVVi/v0brdZAcrcTV+04agKzWtvWroyFz6IqtT0MoZJA7PNyLVw==,
+        integrity: sha512-Z+56e/Ljt0bUs+T+jPjhFyxYBcdY2RIq9ELFU+qAMQMteHo7ymbV7CKmlcX59RI9C4YzN8PgMgLyAoi916b5HA==,
       }
     engines: { node: ">= 10" }
     cpu: [x64]
@@ -1381,8 +1388,8 @@ packages:
       }
     dependencies:
       "@podcodar/eslint-config-react": 1.6.0(eslint@8.39.0)
-      eslint-config-next: 13.4.10(eslint@8.39.0)(typescript@5.0.2)
-      next: 13.4.10(@babel/core@7.22.1)(react-dom@18.2.0)(react@18.2.0)
+      eslint-config-next: 13.4.12(eslint@8.39.0)(typescript@5.0.2)
+      next: 13.4.12(@babel/core@7.22.1)(react-dom@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - "@babel/core"
       - "@opentelemetry/api"
@@ -3559,10 +3566,10 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-config-next@13.4.10(eslint@8.39.0)(typescript@5.0.2):
+  /eslint-config-next@13.4.12(eslint@8.39.0)(typescript@5.0.2):
     resolution:
       {
-        integrity: sha512-+JjcM6lQmFR5Mw0ORm9o1CR29+z/uajgSfYAPEGIBxOhTHBgCMs7ysuwi72o7LkMmA8E3N7/h09pSGZxs0s85g==,
+        integrity: sha512-ZF0r5vxKaVazyZH/37Au/XItiG7qUOBw+HaH3PeyXltIMwXorsn6bdrl0Nn9N5v5v9spc+6GM2ryjugbjF6X2g==,
       }
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -3571,7 +3578,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      "@next/eslint-plugin-next": 13.4.10
+      "@next/eslint-plugin-next": 13.4.12
       "@rushstack/eslint-patch": 1.3.0
       "@typescript-eslint/parser": 5.59.8(eslint@8.39.0)(typescript@5.0.2)
       eslint: 8.39.0
@@ -6050,10 +6057,10 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /next@13.4.10(@babel/core@7.22.1)(react-dom@18.2.0)(react@18.2.0):
+  /next@13.4.12(@babel/core@7.22.1)(react-dom@18.2.0)(react@18.2.0):
     resolution:
       {
-        integrity: sha512-4ep6aKxVTQ7rkUW2fBLhpBr/5oceCuf4KmlUpvG/aXuDTIf9mexNSpabUD6RWPspu6wiJJvozZREhXhueYO36A==,
+        integrity: sha512-eHfnru9x6NRmTMcjQp6Nz0J4XH9OubmzOa7CkWL+AUrUxpibub3vWwttjduu9No16dug1kq04hiUUpo7J3m3Xw==,
       }
     engines: { node: ">=16.8.0" }
     hasBin: true
@@ -6071,7 +6078,7 @@ packages:
       sass:
         optional: true
     dependencies:
-      "@next/env": 13.4.10
+      "@next/env": 13.4.12
       "@swc/helpers": 0.5.1
       busboy: 1.6.0
       caniuse-lite: 1.0.30001491
@@ -6082,15 +6089,15 @@ packages:
       watchpack: 2.4.0
       zod: 3.21.4
     optionalDependencies:
-      "@next/swc-darwin-arm64": 13.4.10
-      "@next/swc-darwin-x64": 13.4.10
-      "@next/swc-linux-arm64-gnu": 13.4.10
-      "@next/swc-linux-arm64-musl": 13.4.10
-      "@next/swc-linux-x64-gnu": 13.4.10
-      "@next/swc-linux-x64-musl": 13.4.10
-      "@next/swc-win32-arm64-msvc": 13.4.10
-      "@next/swc-win32-ia32-msvc": 13.4.10
-      "@next/swc-win32-x64-msvc": 13.4.10
+      "@next/swc-darwin-arm64": 13.4.12
+      "@next/swc-darwin-x64": 13.4.12
+      "@next/swc-linux-arm64-gnu": 13.4.12
+      "@next/swc-linux-arm64-musl": 13.4.12
+      "@next/swc-linux-x64-gnu": 13.4.12
+      "@next/swc-linux-x64-musl": 13.4.12
+      "@next/swc-win32-arm64-msvc": 13.4.12
+      "@next/swc-win32-ia32-msvc": 13.4.12
+      "@next/swc-win32-x64-msvc": 13.4.12
     transitivePeerDependencies:
       - "@babel/core"
       - babel-plugin-macros
@@ -7924,6 +7931,18 @@ packages:
       json5: 1.0.2
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  /tsconfig-paths@4.2.0:
+    resolution:
+      {
+        integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==,
+      }
+    engines: { node: ">=6" }
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+    dev: true
 
   /tslib@1.14.1:
     resolution:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "ts-node": {
+    "require": ["tsconfig-paths/register"]
+  },
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],


### PR DESCRIPTION
# Description

This PR Fix Docker-compose Seeding

- Added pnpm i && before db seed on docker-compose
- Use --project to explicitly specify the path to a tsconfig.json on package.json
- Add ts-node together with tsconfig-paths to load modules according to the paths section in tsconfig.json
