### PR TITLE
User tasks on the dashboard is now integrated with the DB

### DIFF
--- a/src/app/api/tasks/completed/route.ts
+++ b/src/app/api/tasks/completed/route.ts
@@ -1,0 +1,20 @@
+import { task } from "@/shared/tasks.dao";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const checkUserTaskParams = z
+  .object({
+    userId: z.number(),
+    taskId: z.number(),
+    completed: z.boolean(),
+  })
+  .strict();
+
+export async function PUT(req: NextRequest) {
+  const data = await req.json();
+  const { userId, taskId, completed } = checkUserTaskParams.parse(data);
+
+  const userTask = await task.checkUserTask(taskId, userId, completed);
+
+  return NextResponse.json(userTask);
+}

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,7 +1,14 @@
 import TaskList from "@/components/TaskList";
-import { items } from "@/shared/settings";
+import { authOptions, fetchUserWithSession } from "@/shared/auth";
+import { task } from "@/shared/tasks.dao";
+import { getServerSession } from "next-auth";
 
-export default function Dashboard() {
+export default async function Dashboard() {
+  const session = await getServerSession(authOptions);
+
+  const loggedUser = await fetchUserWithSession(session);
+  const userTasks = await task.fetchUserTasksBy({ userId: loggedUser.id });
+
   return (
     <div className="min-h-full">
       <div className="bg-white shadow">
@@ -10,9 +17,8 @@ export default function Dashboard() {
             Dashboard
           </h1>
         </div>
-
         <div className="mx-auto max-w-7xl py-6 sm:-6 lg:px-8">
-          <TaskList items={items} />
+          <TaskList tasks={userTasks} />
         </div>
       </div>
     </div>

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -60,7 +60,6 @@ function ExpandableTaskItem({ userTask }: { userTask: UserTask }) {
         <input
           checked={isChecked}
           className="mr-2 mt-3 ml-2 h-6 w-6 inline-block"
-          id={userTask.Task.id.toString()}
           onChange={handleCheckboxChange}
           type="checkbox"
         />

--- a/src/entities/tasks.ts
+++ b/src/entities/tasks.ts
@@ -1,5 +1,0 @@
-export type TaskItem = {
-  id: string;
-  label: string;
-  content: string;
-};

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1,0 +1,5 @@
+export const api = {
+  tasks: {
+    completed: "/api/tasks/completed",
+  },
+};

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1,5 +1,3 @@
-import { TaskItem } from "@/entities/tasks";
-
 export const githubCredentials = {
   clientId: process.env.GITHUB_CLIENT_ID as string,
   clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
@@ -19,32 +17,3 @@ export const googleCredentials = {
 
 export const ORIGIN_URL_KEY = "x-url";
 export const NO_SESSION_REDIRECT = "/login?callbackUrl=";
-
-// TODO: Mocked Data: remove after having DB connection settled
-export const items: TaskItem[] = [
-  {
-    id: "pd1",
-    label: "Checklist 1",
-    content: "Yes that the first one",
-  },
-  {
-    id: "pd2",
-    label: "Checklist 2",
-    content: "Yes that the second one",
-  },
-  {
-    id: "pd3",
-    label: "Checklist 3",
-    content: "Yes that the third one",
-  },
-  {
-    id: "pd4",
-    label: "Checklist 4",
-    content: "Yes that the fourth one",
-  },
-  {
-    id: "pd5",
-    label: "Checklist 5",
-    content: "Yes that the fifth one",
-  },
-];

--- a/src/shared/tasks.dao.ts
+++ b/src/shared/tasks.dao.ts
@@ -1,9 +1,36 @@
+import { Prisma } from "@prisma/client";
 import { prisma } from "./db";
 
 class TaskDAO {
   async listNoDependenciesTasks() {
     return await prisma.task.findMany({
       where: { dependsOn: { none: {} } },
+    });
+  }
+
+  async fetchTaskById(id: number) {
+    return await prisma.task.findUniqueOrThrow({
+      where: {
+        id,
+      },
+    });
+  }
+
+  async fetchUserTasksBy(where: Prisma.UserTasksWhereInput) {
+    return await prisma.userTasks.findMany({
+      where,
+      include: {
+        Task: true,
+      },
+    });
+  }
+
+  async checkUserTask(taskId: number, userId: number, completed: boolean) {
+    return prisma.userTasks.update({
+      where: {
+        userId_taskId: { userId, taskId },
+      },
+      data: { completed },
     });
   }
 }


### PR DESCRIPTION
# Description

This PR now gets and sets tasks on the DB instead of local storage. This PR closes issue #58

- Remove old local storage logic
- Create TaskDAO method for checking tasks
- Create Next API route for checking tasks
- Add logic for getting data from the DB through NextAPI on the front-end
