### PR TITLE
Add `checkType` to Task Schema

### DIFF
--- a/prisma/erd.md
+++ b/prisma/erd.md
@@ -6,6 +6,14 @@ erDiagram
 ADMIN ADMIN
         }
     
+
+
+        CheckType {
+            MANUAL MANUAL
+AUTOMATED AUTOMATED
+VERIFIED VERIFIED
+        }
+    
   "User" {
     Int id "🗝️"
     String name 
@@ -33,6 +41,7 @@ ADMIN ADMIN
     Int id "🗝️"
     String title 
     String description 
+    CheckType checkType 
     }
   
 
@@ -50,6 +59,7 @@ ADMIN ADMIN
     "User" o|--}o "Roles" : "enum:roles"
     "User" o{--}o "UserTasks" : "tasks"
     "Task" o{--}o "UserTasks" : "users"
+    "Task" o|--|| "CheckType" : "enum:checkType"
     "Task" o{--}o "TasksDependencies" : "followUp"
     "Task" o{--}o "TasksDependencies" : "dependsOn"
     "UserTasks" o|--|| "User" : "user"

--- a/prisma/migrations/20230904195212_add_checktype_to_task/migration.sql
+++ b/prisma/migrations/20230904195212_add_checktype_to_task/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `checkType` to the `Task` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "CheckType" AS ENUM ('MANUAL', 'AUTOMATED', 'VERIFIED');
+
+-- AlterTable
+ALTER TABLE "Task" ADD COLUMN     "checkType" "CheckType" NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,8 +48,15 @@ model Task {
   title       String              @unique
   description String
   users       UserTasks[]
+  checkType   CheckType
   followUp    TasksDependencies[] @relation("followUp")
   dependsOn   TasksDependencies[] @relation("dependsOn")
+}
+
+enum CheckType {
+  MANUAL
+  AUTOMATED
+  VERIFIED
 }
 
 model UserTasks {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,18 +1,37 @@
 import { prisma } from "../src/shared/db";
+import { CheckType } from "@prisma/client";
 
 async function main() {
   const tasksData = [
     {
       title: "Seed Task 1",
       description: "Description for Seed Task 1",
+      checkType: CheckType.MANUAL,
     },
     {
       title: "Seed Task 2",
       description: "Description for Seed Task 2",
+      checkType: CheckType.AUTOMATED,
     },
     {
       title: "Seed Task 3",
       description: "Description for Seed Task 3",
+      checkType: CheckType.VERIFIED,
+    },
+    {
+      title: "Seed Task 4",
+      description: "Description for Seed Task 4",
+      checkType: CheckType.MANUAL,
+    },
+    {
+      title: "Seed Task 5",
+      description: "Description for Seed Task 5",
+      checkType: CheckType.AUTOMATED,
+    },
+    {
+      title: "Seed Task 6",
+      description: "Description for Seed Task 6",
+      checkType: CheckType.VERIFIED,
     },
   ];
 

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { ChevronDownIcon, ChevronLeftIcon } from "@heroicons/react/24/outline";
-import { Task, UserTasks } from "@prisma/client";
+import { CheckType, Task, UserTasks } from "@prisma/client";
 import { api } from "@/shared/api";
 
 type UserTask = UserTasks & {
@@ -54,12 +54,15 @@ function ExpandableTaskItem({ userTask }: { userTask: UserTask }) {
     </span>
   );
 
+  const isManuallyChecked = userTask.Task.checkType === CheckType.MANUAL;
+
   return (
     <div key={userTask.Task.id}>
       <div className="flex bg-gray-50 border-b center">
         <input
           checked={isChecked}
           className="mr-2 mt-3 ml-2 h-6 w-6 inline-block"
+          disabled={!isManuallyChecked}
           onChange={handleCheckboxChange}
           type="checkbox"
         />

--- a/src/tests/db.utils.ts
+++ b/src/tests/db.utils.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/shared/db";
 import { raise } from "@/shared/exceptions";
+import { CheckType } from "@prisma/client";
 
 export const seed = async () => {
   // create product categories
@@ -31,14 +32,17 @@ export const seed = async () => {
       {
         title: "Task 1",
         description: "First task",
+        checkType: CheckType.MANUAL,
       },
       {
         title: "Task 2",
         description: "Second task",
+        checkType: CheckType.MANUAL,
       },
       {
         title: "Task 3",
         description: "Third task",
+        checkType: CheckType.MANUAL,
       },
     ],
   });


### PR DESCRIPTION
# Description

This PR adds `checkType` to Task schema

- Update Task Prisma Schema with the new `checkType` column
- Make DB migration
- Update seed function to include the new column
- Create disable logic for the checkbox on the frontend

This PR closes issue #56 