### PR TITLE
fea: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,12 @@
+# Description
+
+As an (user|developer|product person), I wan't to (your description here).
+
+## Dependencies
+
+- list issue dependencies (if needed)
+
+## Tasks
+
+- [ ] do something
+- [ ] do another thing


### PR DESCRIPTION
# Description

This PR adds `ISSUE_TEMPLATE.md` to give us a placeholder issue.


> [!NOTE]
> 
> This can be more dynamic if we follow this: 
> https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository

This closes #83 